### PR TITLE
remove devDependency of gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "gulp-replace": "^1.0.0",
     "gulp-streamify": "^1.0.2",
     "gulp-uglify": "^3.0.1",
-    "gulp-util": "^3.0.8",
     "jshint": "^2.9.7",
     "nock": "^10.0.6",
     "path": "^0.12.7",


### PR DESCRIPTION
issues
- https://github.com/klaytn/caver-js/issues/168

details
- npm warn following message
- deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

work
- remove devDependency

test
- npm test

## Proposed changes

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-js/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-js)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
